### PR TITLE
chore: add staking on mode

### DIFF
--- a/staking_report.py
+++ b/staking_report.py
@@ -89,7 +89,9 @@ def staking_report(config: dict) -> None:
 
         w3 = Web3(HTTPProvider(rpc))
 
-        staking_token_address = STAKING.get(ChainType.OPTIMISM, {}).get("optimus_alpha")
+        home_chain_type = ChainType.from_id(int(home_chain_id))
+        
+        staking_token_address = STAKING.get(home_chain_type, {}).get("optimus_alpha")
         if not staking_token_address:
             print("Error: Staking token address not found for OPTIMISM ChainType.")
             return

--- a/staking_report.py
+++ b/staking_report.py
@@ -90,7 +90,6 @@ def staking_report(config: dict) -> None:
         w3 = Web3(HTTPProvider(rpc))
 
         home_chain_type = ChainType.from_id(int(home_chain_id))
-        
         staking_token_address = STAKING.get(home_chain_type, {}).get("optimus_alpha")
         if not staking_token_address:
             print("Error: Staking token address not found for OPTIMISM ChainType.")
@@ -103,14 +102,13 @@ def staking_report(config: dict) -> None:
         staking_token_contract = w3.eth.contract(
             address=staking_token_address, abi=staking_token_abi  # type: ignore
         )
-
         # Get staking state
         staking_state_value = staking_token_contract.functions.getStakingState(service_id).call()
         staking_state = StakingState(staking_state_value)
         is_staked = staking_state in (StakingState.STAKED, StakingState.EVICTED)
         _print_status("Is service staked?", _color_bool(is_staked, "Yes", "No"))
         if is_staked:
-            _print_status("Staking program", str(staking_program_id))
+            _print_status("Staking program", str(staking_program_id) + str(home_chain_type).rsplit('.', maxsplit=1)[-1])
             _print_status("Staking state", staking_state.name if staking_state == StakingState.STAKED else _color_string(staking_state.name, ColorCode.RED))
 
             # Activity Checker


### PR DESCRIPTION
This pull request includes several changes to the `run_service.py` file and a minor update to `operate/ledger/profiles.py`. The main focus is on extending staking functionality on mode and updating configurations accordingly. 

### Staking Functionality Enhancements:
* Added `staking_chain` as an optional parameter in the `OptimusConfig` class to allow configuration of the staking chain.
* Updated the `configure_local_config` function to prompt users to select the staking chain, with Mode as the default option.
* Added the `staking_chain` parameter to environment variables in the `main` function and included a mapping for staking activity checker contract addresses.
* Included the `CONTRACTS` import in `run_service.py` to ensure all necessary configurations are available.
* Added the `optimus_alpha` address to the `ChainType.MODE` configuration in `operate/ledger/profiles.py`.
* Expanded the `STAKING_CHAINS` list to include "mode" in `run_service.py`.